### PR TITLE
Error handling for SNS mobile push does not match AWS

### DIFF
--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -126,7 +126,7 @@ mock_support = lazy_load(".support", "mock_support")
 # logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 __title__ = "moto"
-__version__ = "1.3.17.dev"
+__version__ = "june.1.3.17.dev"
 
 
 try:

--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -18,13 +18,6 @@ class ResourceNotFoundError(RESTError):
         )
 
 
-class DuplicateSnsEndpointError(RESTError):
-    code = 400
-
-    def __init__(self, message):
-        super(DuplicateSnsEndpointError, self).__init__("DuplicateEndpoint", message)
-
-
 class SnsEndpointDisabled(RESTError):
     code = 400
 

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -343,12 +343,14 @@ class PlatformEndpoint(BaseModel):
 
     @property
     def arn(self):
-        return "arn:aws:sns:{region}:{AccountId}:endpoint/{platform}/{name}/{id}".format(
-            region=self.region,
-            AccountId=DEFAULT_ACCOUNT_ID,
-            platform=self.application.platform,
-            name=self.application.name,
-            id=self.id,
+        return (
+            "arn:aws:sns:{region}:{AccountId}:endpoint/{platform}/{name}/{id}".format(
+                region=self.region,
+                AccountId=DEFAULT_ACCOUNT_ID,
+                platform=self.application.platform,
+                name=self.application.name,
+                id=self.id,
+            )
         )
 
     def publish(self, message):
@@ -584,20 +586,26 @@ class SNSBackend(BaseBackend):
     def create_platform_endpoint(
         self, region, application, custom_user_data, token, attributes
     ):
-        existing = next(iter([
-            endpoint
-            for endpoint in self.platform_endpoints.values()
-            if token == endpoint.token
-        ]), None)
+        existing = next(
+            iter(
+                [
+                    endpoint
+                    for endpoint in self.platform_endpoints.values()
+                    if token == endpoint.token
+                ]
+            ),
+            None,
+        )
 
         if existing is not None:
             if existing.custom_user_data == custom_user_data:
                 platform_endpoint = existing
             else:
-                error_text = \
-                    "Invalid parameter: "\
-                    "Token Reason: Endpoint (%s) already exists with the same "\
+                error_text = (
+                    "Invalid parameter: "
+                    "Token Reason: Endpoint (%s) already exists with the same "
                     "Token, but different attributes." % existing.arn
+                )
                 raise SNSInvalidParameter(error_text)
         else:
             platform_endpoint = PlatformEndpoint(

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -594,10 +594,11 @@ class SNSBackend(BaseBackend):
             if existing.custom_user_data == custom_user_data:
                 platform_endpoint = existing
             else:
-                # Maintain previous exception.  Should be checked against
-                # actual boto behavior.
-                raise DuplicateSnsEndpointError(
-                    "Duplicate endpoint token: %s" % token)
+                error_text = \
+                    "Invalid parameter: "\
+                    "Token Reason: Endpoint (%s) already exists with the same "\
+                    "Token, but different attributes." % existing.arn
+                raise SNSInvalidParameter(error_text)
         else:
             platform_endpoint = PlatformEndpoint(
                 region, application, custom_user_data, token, attributes

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -21,7 +21,6 @@ from moto.awslambda import lambda_backends
 
 from .exceptions import (
     SNSNotFoundError,
-    DuplicateSnsEndpointError,
     SnsEndpointDisabled,
     SNSInvalidParameter,
     InvalidParameterValue,

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,11 @@ def get_version():
 install_requires = [
     "boto3>=1.9.201",
     "botocore>=1.12.201",
-    "cryptography>=3.3.1",
+    "cryptography<3.4",
     "requests>=2.5",
     "xmltodict",
     "six>1.9",
-    "werkzeug",
+    "werkzeug<1.0",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "responses>=0.9.0",
@@ -67,6 +67,9 @@ install_requires += [
     # Indirect - Py2 works with 4.5, breaks with 4.7, but officially only supported by 4.0
     "rsa<=4.0; python_version < '3'",
     "setuptools",
+    # Update following to 44.1.1?
+    # ERROR: pip's legacy dependency resolver does not consider dependency conflicts when selecting packages. This behaviour is the source of the following dependency conflicts.
+    # moto june-1.3.17.dev requires setuptools==44.0.0, but you'll have setuptools 44.1.1 which is incompatible.
     "setuptools==44.0.0; python_version < '3'",
     "zipp",
     "zipp==0.6.0; python_version < '3'",

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -159,15 +159,17 @@ def test_create_duplicate_platform_endpoint():
             PlatformApplicationArn=application_arn,
             Token="some_unique_id",
             CustomUserData="different user data",
-            Attributes={"Enabled": "false"})
+            Attributes={"Enabled": "false"},
+        )
 
     # Check for actual exception text returned by boto3:
     # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#SNS.Client.create_platform_endpoint
-    assert str(e.value) == \
-        "An error occurred (InvalidParameter) when calling the "\
-        "CreatePlatformEndpoint operation: Invalid parameter: "\
-        "Token Reason: Endpoint (%s) already exists with the "\
-        "same Token, but different attributes." % endpoint[u"EndpointArn"]
+    assert (
+        str(e.value) == "An error occurred (InvalidParameter) when calling the "
+        "CreatePlatformEndpoint operation: Invalid parameter: "
+        "Token Reason: Endpoint (%s) already exists with the "
+        "same Token, but different attributes." % endpoint["EndpointArn"]
+    )
 
     # Verify that it is idempotent (when called with identical custom user data).
     endpoint2 = conn.create_platform_endpoint(

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -154,12 +154,16 @@ def test_create_duplicate_platform_endpoint():
 
     # Error should only occur if the endpoint has custom user data
     # which conflicts with data on an existing endpoint.
-    bad_endpoint = conn.create_platform_endpoint.when.called_with(
-        PlatformApplicationArn=application_arn,
-        Token="some_unique_id",
-        CustomUserData="different user data",
-        Attributes={"Enabled": "false"},
-    ).should.throw(ClientError)
+    with pytest.raises(ClientError) as e:
+        conn.create_platform_endpoint(
+            PlatformApplicationArn=application_arn,
+            Token="some_unique_id",
+            CustomUserData="different user data",
+            Attributes={"Enabled": "false"})
+    assert str(e.value) == \
+        "An error occurred (DuplicateEndpoint) when calling the "\
+        "CreatePlatformEndpoint operation: Duplicate endpoint token: "\
+        "some_unique_id"
 
     # Verify that it is idempotent (when called with identical custom user data).
     endpoint2 = conn.create_platform_endpoint(

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -160,10 +160,14 @@ def test_create_duplicate_platform_endpoint():
             Token="some_unique_id",
             CustomUserData="different user data",
             Attributes={"Enabled": "false"})
+
+    # Check for actual exception text returned by boto3:
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#SNS.Client.create_platform_endpoint
     assert str(e.value) == \
-        "An error occurred (DuplicateEndpoint) when calling the "\
-        "CreatePlatformEndpoint operation: Duplicate endpoint token: "\
-        "some_unique_id"
+        "An error occurred (InvalidParameter) when calling the "\
+        "CreatePlatformEndpoint operation: Invalid parameter: "\
+        "Token Reason: Endpoint (%s) already exists with the "\
+        "same Token, but different attributes." % endpoint[u"EndpointArn"]
 
     # Verify that it is idempotent (when called with identical custom user data).
     endpoint2 = conn.create_platform_endpoint(

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -152,12 +152,22 @@ def test_create_duplicate_platform_endpoint():
         Attributes={"Enabled": "false"},
     )
 
-    endpoint = conn.create_platform_endpoint.when.called_with(
+    # Error should only occur if the endpoint has custom user data
+    # which conflicts with data on an existing endpoint.
+    bad_endpoint = conn.create_platform_endpoint.when.called_with(
+        PlatformApplicationArn=application_arn,
+        Token="some_unique_id",
+        CustomUserData="different user data",
+        Attributes={"Enabled": "false"},
+    ).should.throw(ClientError)
+
+    # Verify that it is idempotent (when called with identical custom user data).
+    endpoint2 = conn.create_platform_endpoint(
         PlatformApplicationArn=application_arn,
         Token="some_unique_id",
         CustomUserData="some user data",
         Attributes={"Enabled": "false"},
-    ).should.throw(ClientError)
+    ).should.equal(endpoint)
 
 
 @mock_sns


### PR DESCRIPTION
This branch exists to develop a solution to this open PR on the public `moto` project:
[Error handling for SNS mobile push does not match AWS](https://github.com/spulec/moto/issues/2333)

This issue breaks unit testing of SNS endpoint functionality in `june-auth`

Currently working for us with this change.
Further refinement is needed in order to make this ready for a PR against the public `moto` project.